### PR TITLE
Fix undefined symbol error for ucc_tl_spin_coll_worker_rx_reliability_get_missing_ranks in debug build

### DIFF
--- a/ucc/src/components/tl/spin/tl_spin_bcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_bcast.c
@@ -243,7 +243,7 @@ ucc_tl_spin_coll_worker_tx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
     return UCC_OK;
 }
 
-inline void
+static inline void
 ucc_tl_spin_coll_worker_rx_reliability_get_missing_ranks(ucc_tl_spin_worker_info_t *ctx, 
                                                          ucc_tl_spin_task_t *cur_task)
 {


### PR DESCRIPTION
### Summary
This PR fixes an undefined symbol error related to `ucc_tl_spin_coll_worker_rx_reliability_get_missing_ranks` that occurs during debug compilation.

### Why this change is needed?
- Debug builds (`-O0`) do not always inline functions, leading to missing symbols at link time.
- This fix ensures that the function is properly linked even in debug builds.