### PR TITLE
fix errors in compiling UCC with --enable-debug

### DIFF
--- a/ucc/src/components/tl/spin/tl_spin_mcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_mcast.c
@@ -109,7 +109,7 @@ ucc_tl_spin_team_join_mcg(ucc_tl_spin_context_t *ctx, struct sockaddr_in6 *mcg_s
     /* it is time to wait for the rdma event to confirm the join */
     info->status = ucc_tl_spin_mcast_join_mcast_test(ctx, &cm_event, is_root, 1); // TODO: make nonblocking
     if ((info->status == UCC_OK)) {
-        ucc_assert(cm_event);
+        ucc_assert(cm_event != NULL);
         info->mcg_addr.gid = cm_event->param.ud.ah_attr.grh.dgid;
         info->mcg_addr.lid = cm_event->param.ud.ah_attr.dlid;
 

--- a/ucc/src/components/tl/spin/tl_spin_team.c
+++ b/ucc/src/components/tl/spin/tl_spin_team.c
@@ -499,7 +499,6 @@ ucc_tl_spin_team_init_rc_qp_ring(ucc_base_team_t *tl_team, struct ibv_cq *cq, st
     // Connect QPs in a virtual ring
     l_neighbor = (team->subset.myrank + 1)              % team->size;
     r_neighbor = (team->subset.myrank - 1 + team->size) % team->size;
-    assert(team_size == 2);
     status = ib_qp_rc_connect(lib, qps[UCC_TL_SPIN_LN_QP_ID], &send_av[0], &recv_av[l_neighbor * 2 + 1]);
     ucc_assert_always(status == UCC_OK);
     status = ib_qp_rc_connect(lib, qps[UCC_TL_SPIN_RN_QP_ID], &send_av[1], &recv_av[r_neighbor * 2]);


### PR DESCRIPTION
I got the following two errors in compiling UCC with --enable-debug flag. This PR fixes these errors.

```bash
tl_spin_mcast.c: In function ‘ucc_tl_spin_team_join_mcg’:
tl_spin_mcast.c:112:20: error: passing argument 1 of ‘__builtin_expect’ makes integer from pointer without a cast [-Werror=int-conversion]
  112 |         ucc_assert(cm_event);
      |                    ^~~~~~~~
      |                    |
      |                    struct rdma_cm_event *
```

```bash
tl_spin_team.c:502:12: error: ‘team_size’ undeclared (first use in this function); did you mean ‘umad_size’?
  502 |     assert(team_size == 2);
      |            ^~~~~~~~~
tl_spin_team.c:502:12: note: each undeclared identifier is reported only once for each function it appears in
```

---

Build command is here.

```bash
cd ucc && \
./autogen.sh && \
./configure \
        --prefix=$(PREFIX) \
        --with-ucx=$(PREFIX) \
        --with-tls=all \
        --with-cuda=$(CUDA_DIR) && \
make -j && \
make install
```