### PR TITLE
CUDA memory support

### DIFF
--- a/ucc/src/components/tl/spin/tl_spin.h
+++ b/ucc/src/components/tl/spin/tl_spin.h
@@ -273,6 +273,8 @@ typedef struct ucc_tl_spin_task {
     double                       timeout;
     void                        *src_ptr;
     void                        *dst_ptr;
+    ucc_memory_type_t            src_mem_type;
+    ucc_memory_type_t            dst_mem_type;
     ucc_tl_spin_rcache_region_t *cached_sbuf_mkey;
     ucc_tl_spin_rcache_region_t *cached_rbuf_mkey;
 #ifdef UCC_TL_SPIN_PROFILE_TASK

--- a/ucc/src/components/tl/spin/tl_spin_allgather.c
+++ b/ucc/src/components/tl/spin/tl_spin_allgather.c
@@ -109,6 +109,8 @@ ucc_status_t ucc_tl_spin_allgather_init(ucc_tl_spin_task_t   *task,
     } else {
         task->src_ptr = task->dst_ptr + UCC_TL_TEAM_RANK(team) * task->src_buf_size;
     }
+    task->src_mem_type = coll_args->args.src.info.mem_type;
+    task->dst_mem_type = coll_args->args.dst.info.mem_type;
 
     ucc_tl_spin_bcast_init_task_tx_info(task, ctx);
     task->pkts_to_send = task->tx_thread_work / ctx->mcast.mtu;

--- a/ucc/src/components/tl/spin/tl_spin_bcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_bcast.c
@@ -3,6 +3,7 @@
 #include "tl_spin_mcast.h"
 #include "tl_spin_p2p.h"
 #include "tl_spin_bitmap.h"
+#include "components/mc/ucc_mc.h"
 
 static ucc_status_t ucc_tl_spin_bcast_start(ucc_coll_task_t *coll_task)
 {
@@ -97,6 +98,8 @@ ucc_status_t ucc_tl_spin_bcast_init(ucc_tl_spin_task_t   *task,
 
     task->src_ptr          = coll_args->args.src.info.buffer;
     task->dst_ptr          = coll_args->args.src.info.buffer;
+    task->src_mem_type     = coll_args->args.src.info.mem_type;
+    task->dst_mem_type     = coll_args->args.dst.info.mem_type;
     task->src_buf_size     = task->dst_buf_size = count * dt_size;
     ucc_assert_always(task->src_buf_size <= ctx->cfg.max_recv_buf_size);
 
@@ -584,9 +587,13 @@ ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
                 ucc_assert_always(rank_id == 0);
             }
             rank_buf_offset = chunk_id % cur_task->pkts_to_send;
-            memcpy(buf + cur_task->src_buf_size * rank_id + mtu * rank_buf_offset, 
-                   rbuf + mtu * (*tail_idx),
-                   pkt_len);
+            ucc_status_t status;
+            status = ucc_mc_memcpy(PTR_OFFSET(buf, cur_task->src_buf_size * rank_id + mtu * rank_buf_offset),
+                                   PTR_OFFSET(rbuf, mtu * (*tail_idx)),
+                                   pkt_len,
+                                   cur_task->src_mem_type,
+                                   cur_task->dst_mem_type);
+            ucc_assert_always(status == UCC_OK);
             ucc_tl_spin_bitmap_set_bit(&ctx->reliability.bitmap, chunk_id);
             ctx->reliability.recvd_per_rank[rank_id]++;
             ctx->reliability.to_recv--;

--- a/ucc/src/components/tl/spin/tl_spin_team.c
+++ b/ucc/src/components/tl/spin/tl_spin_team.c
@@ -707,7 +707,7 @@ ucc_status_t ucc_tl_spin_team_get_scores(ucc_base_team_t *tl_team,
     ucc_tl_spin_team_t *team  = ucc_derived_of(tl_team, ucc_tl_spin_team_t);
     ucc_base_context_t *ctx   = UCC_TL_TEAM_CTX(team);
     ucc_base_lib_t     *lib   = UCC_TL_TEAM_LIB(team);
-    ucc_memory_type_t   mt[1] = {UCC_MEMORY_TYPE_HOST};
+    ucc_memory_type_t   mt[2] = {UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA};
     ucc_coll_score_t          *score;
     ucc_status_t               status;
     ucc_coll_score_team_info_t team_info;
@@ -715,7 +715,7 @@ ucc_status_t ucc_tl_spin_team_get_scores(ucc_base_team_t *tl_team,
     team_info.alg_fn              = NULL;
     team_info.default_score       = UCC_TL_SPIN_DEFAULT_SCORE;
     team_info.init                = ucc_tl_spin_coll_init;
-    team_info.num_mem_types       = 1;
+    team_info.num_mem_types       = 2;
     team_info.supported_mem_types = mt;
     team_info.supported_colls     = UCC_TL_SPIN_SUPPORTED_COLLS;
     team_info.size                = UCC_TL_TEAM_SIZE(team);


### PR DESCRIPTION
Hi multicast-based-allgather team,

This PR enables CUDA memory support in TL/SPIN (related to #5).

The core change is replacing `memcpy` with `ucc_mc_memcpy` to properly support device memory.
With only this modification, TL/SPIN now supports Allgather (and Bcast) using CUDA buffers.

### Changes

- Replaced all uses of `memcpy` with `ucc_mc_memcpy` for memory-type-aware copying
- Added `src_mem_type` and `dst_mem_type` fields to `ucc_tl_spin_task_t`

### Testing

- Passed MPI unit tests for Allgather with CUDA device memory
- Successfully trained PyTorch FSDP with TL/SPIN Allgather

Test scripts can be shared upon request.

Thank you!